### PR TITLE
Feature: Support primitive list

### DIFF
--- a/buildSrc/src/BuildConstants.groovy
+++ b/buildSrc/src/BuildConstants.groovy
@@ -30,6 +30,8 @@ interface Versions {
     static mockito = '2.23.4'
     static powermock = '1.7.4'
     static hamcrest = '1.3'
+
+    static jackson = '2.9.6'
 }
 
 
@@ -48,6 +50,9 @@ interface Libraries {
     static jcl_over_slf4j = "org.slf4j:jcl-over-slf4j:${Versions.slf4j}"
     static log4j_over_slf4j = "org.slf4j:log4j-over-slf4j:${Versions.slf4j}"
     static logback = "ch.qos.logback:logback-classic:${Versions.logback}"
+
+    static jackson_databind = "com.fasterxml.jackson.core:jackson-databind:${Versions.jackson}"
+    static jackson_core = "com.fasterxml.jackson.core:jackson-core:${Versions.jackson}"
 
     // test dependencies
     static junit4 = "junit:junit:${Versions.junit4}"

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,7 @@
 
   <modules>
     <module>beanfiller-tcases</module>
+    <module>samples/list-sample</module>
     <module>samples</module>
     <module>samples/find-sample</module>
     <module>samples/testng-sample</module>

--- a/samples/list-sample/README.md
+++ b/samples/list-sample/README.md
@@ -1,0 +1,20 @@
+# List sample
+
+Sample generating a lists of values with tcases first, and then using this list as a value for a second round of TCases.
+
+## Dynamic structures
+
+### List of coins in change machine
+
+Model as integer variables for each coin
+
+### List of children
+
+Example getTaxBenefit(double Income, List<Child> children);
+
+Each child: Firstname, lastname, date of birth, gender
+
+With JSon Serialization
+SizeBoundaries: min-1, min, max, max+1
+Add uniqueness.
+use additional property/conditions: xxx.MINSAMPLE, for all other outer variables, add when(xxx.MINSAMPLE)

--- a/samples/list-sample/build.gradle
+++ b/samples/list-sample/build.gradle
@@ -1,0 +1,20 @@
+JavaSetup.configure(project)
+
+dependencies {
+    testCompile project(':beanfiller-tcases')
+    // for real-world projects
+    // testCompile 'io.github.beanfiller:tcases-annotation:[latestVersion]'
+
+    // only for TestNg example
+    testCompile "org.testng:testng:${Versions.testng}"
+
+    // optional
+    testRuntime "ch.qos.logback:logback-classic:${Versions.logback}"
+
+    compile Libraries.jackson_core
+    compile Libraries.jackson_databind
+
+    testCompileOnly Libraries.jsr305
+    testCompile LibraryGroups.unit_test
+    testRuntime Libraries.logback
+}

--- a/samples/list-sample/pom.xml
+++ b/samples/list-sample/pom.xml
@@ -1,0 +1,127 @@
+<project 
+    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.beanfiller</groupId>
+    <artifactId>samples</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>list-sample</artifactId>
+  <packaging>jar</packaging>
+
+  <name>List Sample</name>
+  <description>Generates test cases using list properties</description>
+  <url>https://github.com/Cornutum/tcases</url>
+
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.date>${maven.build.timestamp}</project.build.date>
+    <maven.build.timestamp.format>yyyy-MM-dd</maven.build.timestamp.format>
+  </properties>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+
+    <testResources>
+      <testResource>
+        <directory>src/test/resources</directory>
+        <filtering>true</filtering>
+      </testResource>
+    </testResources>
+
+  </build>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.19.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.9.6</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.9.6</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.10.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.cornutum.tcases</groupId>
+      <artifactId>tcases-lib</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <!-- For better xml1.1 support -->
+    <!--    <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+      <version>2.12.0</version>
+      <scope>runtime</scope>
+    </dependency>-->
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.6</version>
+    </dependency>
+
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/ArrayMapper.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/ArrayMapper.java
@@ -1,0 +1,62 @@
+/* Copyright 2018 The Beanfiller Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package io.github.beanfiller.annotation.sample;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.beanfiller.annotation.creator.VariableToClassValueMapper;
+import io.github.beanfiller.annotation.internal.reader.FieldWrapper;
+import org.cornutum.tcases.VarBinding;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.Collection;
+
+public class ArrayMapper implements VariableToClassValueMapper {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Override
+    public boolean appliesTo(@Nonnull final String varname, @Nonnull final Class<?> parentClass) {
+        final FieldWrapper field = getField(parentClass, varname);
+        if (Collection.class.isAssignableFrom(field.getType())) {
+            return true;
+        }
+        if (field.getType().isArray()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setFieldValueAs(@Nonnull final String varname, @Nonnull final Object instance, @Nonnull final VarBinding varBinding) {
+        final FieldWrapper field = getField(instance.getClass(), varname);
+        final Object value;
+        try {
+            value = OBJECT_MAPPER.readValue(varBinding.getValue().toString(), field.getType());
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot deserialize field " + varname, e);
+        }
+        setFieldValue(instance, varname, value);
+    }
+
+    public static <T> String encodeToString(Collection<T> list) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(list);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/CircleIterator.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/CircleIterator.java
@@ -1,0 +1,36 @@
+package io.github.beanfiller.annotation.sample;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class CircleIterator<T> {
+    private Iterator<T> iterator;
+    private boolean exhausted = false;
+    private final Collection<T> wrapped;
+
+    public CircleIterator(final Collection<T> wrapped) {
+        this.wrapped = wrapped;
+        iterator = wrapped.iterator();
+        if (!iterator.hasNext()) {
+            throw new IllegalStateException("Iterator exhausted after creation");
+        }
+    }
+
+    public T next() {
+        if (!iterator.hasNext()) {
+            iterator = wrapped.iterator();
+            if (!iterator.hasNext()) {
+                throw new IllegalStateException("Iterator exhausted after creation");
+            }
+        }
+        T result = iterator.next();
+        if (!iterator.hasNext()) {
+            exhausted = true;
+        }
+        return result;
+    }
+
+    public boolean isExhausted() {
+        return exhausted;
+    }
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/IceCreamTestInput.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/IceCreamTestInput.java
@@ -1,0 +1,99 @@
+/* Copyright 2018 The Beanfiller Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package io.github.beanfiller.annotation.sample;
+
+import io.github.beanfiller.annotation.annotations.Var;
+import io.github.beanfiller.annotation.creator.AbstractTestInput;
+import io.github.beanfiller.annotation.creator.FunctionTestsCreator;
+import io.github.beanfiller.annotation.creator.ReflectionBasedInstanceCreator;
+import org.cornutum.tcases.VarValueDef;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static io.github.beanfiller.annotation.sample.ListEquivalenceClasses.getVarValueDefs;
+
+public class IceCreamTestInput extends AbstractTestInput {
+
+    private enum Extra {
+        CREAM,
+        CHOCOLATE_SPRINKLES,
+        CHOCOLATE_SAUCE,
+        KETCHUP
+    }
+
+    private static List<VarValueDef> extras() {
+        return getVarValueDefs(
+                Arrays.asList(Extra.CHOCOLATE_SPRINKLES, Extra.CHOCOLATE_SAUCE, Extra.CREAM),
+                Arrays.asList(Extra.KETCHUP),
+                0,
+                2,
+                Extra::valueOf);
+    }
+
+    // TODO:
+    // - Allow Collection
+    // - Unwrap wrapped in instance Creator
+    // - genrator method to annotation
+    // - globale condition for other variables
+
+    @Var(generator = "extras", nullable = false)
+    public SimpleTestInput<Extra>[] extras;
+
+    private enum Flavour {
+        CHOCOLATE,
+        VANILLA,
+        STRAWBERRY,
+        WALNUT,
+        MINT,
+        PINEAPPLE,
+        LEMON,
+        CHERRY,
+        BEEF,
+        CAMENBERT
+    }
+
+    private static List<VarValueDef> flavours() {
+        return getVarValueDefs(
+                Arrays.asList(Flavour.CHOCOLATE, Flavour.PINEAPPLE, Flavour.LEMON, Flavour.CHERRY,
+                        Flavour.VANILLA, Flavour.STRAWBERRY, Flavour.WALNUT, Flavour.MINT),
+                Arrays.asList(Flavour.BEEF, Flavour.CAMENBERT),
+                1,
+                4,
+                Flavour::valueOf);
+    }
+
+    @Var(generator = "flavours", nullable = false)
+    public SimpleTestInput<Flavour>[] flavours;
+
+
+    public static void main(String[] args) {
+        int tupleSize = 2;
+        List<IceCreamTestInput> testCases = new FunctionTestsCreator<>(IceCreamTestInput.class)
+                // Special mapper to extract JSon from String
+                .instanceCreator(ReflectionBasedInstanceCreator.withMappers(new ArrayMapper()))
+                .tupleGenerator(tupleSize)
+                .createDefs();
+        testCases.forEach(test -> System.out.println(test.toString()));
+    }
+
+    @Override
+    public String toString() {
+        return (isFailure() ? "FAIL: " : "SUCCEED: ")
+                + "flavours=" + Arrays.toString(flavours)
+                + ", extras=" + Arrays.toString(extras);
+    }
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/ListEquivalenceClasses.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/ListEquivalenceClasses.java
@@ -1,0 +1,124 @@
+package io.github.beanfiller.annotation.sample;
+
+import io.github.beanfiller.annotation.builders.VarDefBuilder;
+import io.github.beanfiller.annotation.builders.VarValueDefBuilder;
+import io.github.beanfiller.annotation.creator.FunctionTestsCreator;
+import io.github.beanfiller.annotation.creator.ReflectionBasedInstanceCreator;
+import io.github.beanfiller.annotation.creator.TestMetadataAware;
+import org.cornutum.tcases.FunctionInputDef;
+import org.cornutum.tcases.VarValueDef;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static io.github.beanfiller.annotation.builders.FunctionInputDefBuilder.function;
+
+public class ListEquivalenceClasses {
+    /**
+     * @return a list of arrays to test
+     */
+    public static <T extends TestMetadataAware> List<ListTestInput<T>> combine(
+            final List<T> testcases,
+            final int min,
+            final int max,
+            final boolean includeNull) {
+        final List<ListTestInput<T>> result = new ArrayList<>();
+        if (includeNull) {
+            result.add(null);
+        }
+        final int actualMin = Math.max(0, min);
+
+        if (actualMin > max) {
+            throw new IllegalStateException("Min > max " + min + " > " + max);
+        }
+
+        final CircleIterator<T> validsIterator = new CircleIterator<>(testcases.stream()
+                .filter(testcase -> !testcase.isFailure()).collect(Collectors.toList()));
+
+        // create 1 minimal valid instance (boundary)
+        final ListTestInput<T> minResult = new ListTestInput<>();
+        for (int i = 0; i < actualMin; i++) {
+            minResult.add(validsIterator.next());
+        }
+        result.add(minResult);
+
+        if (actualMin > 0) {
+            // create one minimal invalid sample
+            final ListTestInput<T> tooSmallResult = new ListTestInput<>();
+            tooSmallResult.setTestMetadata(0, true, null);
+            for (int i = 0; i < (actualMin - 1); i++) {
+                tooSmallResult.add(validsIterator.next());
+            }
+            result.add(tooSmallResult);
+        }
+
+        // create 1 or more maximal instances
+        // keep consuming valids until exhausted, then start from beginning
+        while (!validsIterator.isExhausted()) {
+            final ListTestInput<T> maxResult = new ListTestInput<>();
+            for (int i = 0; i < max; i++) {
+                if (validsIterator.isExhausted() && (i >= min)) {
+                    break;
+                }
+                maxResult.add(validsIterator.next());
+            }
+            result.add(maxResult);
+        }
+
+        // create a max + 1 instance
+        final ListTestInput<T> tooBigResult = new ListTestInput<>();
+        for (int i = 0; i < (max + 1); i++) {
+            tooBigResult.add(validsIterator.next());
+        }
+        tooBigResult.setTestMetadata(0, true, null);
+        result.add(tooBigResult);
+
+        // create invalid instances
+        final Iterator<T> invalidsIterator = testcases.stream()
+                .filter(TestMetadataAware::isFailure).collect(Collectors.toList()).iterator();
+
+        while (invalidsIterator.hasNext()) {
+            final ListTestInput<T> invalidResult = new ListTestInput<>();
+            invalidResult.setTestMetadata(0, true, null);
+            invalidResult.add(invalidsIterator.next()); // the rotten apple
+            for (int i = 1; i < min; i++) {
+                invalidResult.add(validsIterator.next()); // good filler values
+            }
+            result.add(invalidResult);
+        }
+
+        return result;
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static <T extends Enum<?>> List<VarValueDef> getVarValueDefs(
+            List<T> valid,
+            List<T> invalid,
+            int min, int max,
+            final Function<String, T> stringToValueMapper) {
+        final VarDefBuilder varDefBuilder = VarDefBuilder.varDef("wrapped");
+        for (final T extra: valid) {
+            varDefBuilder.addValue(new VarValueDefBuilder(extra.name()).build());
+        }
+        for (final T extra: invalid) {
+            varDefBuilder.addValue(new VarValueDefBuilder(extra.name(), VarValueDef.Type.FAILURE).build());
+        }
+
+        final FunctionInputDef funInputDef = function("allExtras").addVarDef(varDefBuilder.build()).build();
+        /* generate testcases */
+
+        final List<SimpleTestInput> list = new FunctionTestsCreator<>(funInputDef, SimpleTestInput.class)
+                .instanceCreator(ReflectionBasedInstanceCreator.withMappers(new WrappedTestInputMapper<>(stringToValueMapper)))
+                .createDefs();
+
+        return combine(list, min, max, false)
+                .stream()
+                .map((ListTestInput<SimpleTestInput> i) -> new VarValueDef(
+                        ArrayMapper.encodeToString(i),
+                        i.isFailure() ? VarValueDef.Type.FAILURE : VarValueDef.Type.VALID))
+                .collect(Collectors.toList());
+    }
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/ListTestInput.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/ListTestInput.java
@@ -1,0 +1,77 @@
+/* Copyright 2018 The Beanfiller Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package io.github.beanfiller.annotation.sample;
+
+import io.github.beanfiller.annotation.creator.OutputAnnotationContainer;
+import io.github.beanfiller.annotation.creator.TestMetadataAware;
+
+import javax.annotation.Nonnull;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class ListTestInput<T> extends AbstractList<T> implements TestMetadataAware {
+
+    private final List<T> wrapped;
+    private int testCaseId;
+
+    private boolean failure;
+
+    private OutputAnnotationContainer outputAnnotations;
+
+    @Override
+    public void setTestMetadata(int id, boolean isFailure, @Nonnull OutputAnnotationContainer outputAnnotationContainer) {
+        this.testCaseId = id;
+        this.failure = isFailure;
+        this.outputAnnotations = outputAnnotationContainer;
+    }
+
+    public int getTestCaseId() {
+        return testCaseId;
+    }
+
+    public OutputAnnotationContainer having() {
+        return outputAnnotations;
+    }
+
+    public boolean isFailure() {
+        return failure;
+    }
+
+    public ListTestInput() {
+        this(new ArrayList<>());
+    }
+
+    public ListTestInput(List<T> wrapped) {
+        this.wrapped = wrapped;
+    }
+
+    @Override
+    public T get(final int index) {
+        return wrapped.get(index);
+    }
+
+    @Override
+    public int size() {
+        return wrapped.size();
+    }
+
+    @Override
+    public boolean add(final T t) {
+        return wrapped.add(t);
+    }
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/SimpleTestInput.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/SimpleTestInput.java
@@ -1,0 +1,38 @@
+/* Copyright 2018 The Beanfiller Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+package io.github.beanfiller.annotation.sample;
+
+import io.github.beanfiller.annotation.creator.AbstractTestInput;
+
+/**
+ * ListEquivalenceClasses framework will:
+ * - create variables that will fill the 'public field'
+ * - use Tcases to create instances of this class with wrapped filled using stringToValue
+ * - use TestMetadataAware.setTestMetadata to set failure value
+ * - use TestMetadataAware.isFailure to classify results accordingly
+ */
+public class SimpleTestInput<T> extends AbstractTestInput {
+
+    public SimpleTestInput() {
+    }
+
+    public T wrapped;
+
+    @Override
+    public String toString() {
+        return wrapped.toString();
+    }
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/TcasesList.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/TcasesList.java
@@ -1,0 +1,10 @@
+package io.github.beanfiller.annotation.sample;
+
+import java.util.Collection;
+
+public abstract class TcasesList<T> {
+
+    public abstract Class<T> getElementClass();
+
+    public abstract Collection<T> createFillerElements(int i);
+}

--- a/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/WrappedTestInputMapper.java
+++ b/samples/list-sample/src/test/java/io/github/beanfiller/annotation/sample/WrappedTestInputMapper.java
@@ -1,0 +1,30 @@
+package io.github.beanfiller.annotation.sample;
+
+import io.github.beanfiller.annotation.creator.VariableToClassValueMapper;
+import org.cornutum.tcases.VarBinding;
+
+import javax.annotation.Nonnull;
+import java.util.function.Function;
+
+public class WrappedTestInputMapper<E extends Enum<?>> implements VariableToClassValueMapper {
+
+    private final Function<String, E> stringToValue;
+
+    public WrappedTestInputMapper(Function<String, E> stringToValue) {
+        this.stringToValue = stringToValue;
+    }
+
+    @Override
+    public boolean appliesTo(@Nonnull final String varname, @Nonnull final Class<?> parentClass) {
+        if (SimpleTestInput.class.isAssignableFrom(parentClass)) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void setFieldValueAs(@Nonnull final String varname, @Nonnull final Object instance, @Nonnull final VarBinding varBinding) {
+        setFieldValue(instance, varname, stringToValue.apply(varBinding.getValue().toString()));
+    }
+
+}

--- a/samples/list-sample/src/test/resources/logback-test.xml
+++ b/samples/list-sample/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.padual.com/java/logback.xsd">
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>
+                %d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+    <logger name="io.github.beanfiller.annotation" level="WARN">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+</configuration>

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,7 +1,7 @@
 rootProject.name = 'beanfiller-tcases'
 
 include 'beanfiller-tcases'
-['samples':  ['find-sample', 'testng-sample']].each( {folder, subprojects ->
+['samples':  ['find-sample', 'testng-sample', 'list-sample']].each( {folder, subprojects ->
     subprojects.each({subproject ->
         include(subproject)
         project(':' + subproject).projectDir = file(folder + '/'+ subproject)


### PR DESCRIPTION
Feature request: As a tester I want beanfiller-tcases to populate a list of values of different sizes with different values.

Solution approach: Define special TCases variables when reading the input and use them when instantiating the class.